### PR TITLE
Support global katex macros from book.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,13 @@ module.exports = {
         end: '$$'
       },
       process(block) {
+        let config = this.book.config.get('pluginsConfig.katex-plus', {})
+        let macros = config['macros'] || {}
         let output = ''
         try {
           output = katex.renderToString(block.body, {
-            displayMode: true
+            displayMode: true,
+            macros: macros
           })
         } catch (e) {
           console.error(e)
@@ -41,10 +44,13 @@ module.exports = {
         end: '$'
       },
       process(block) {
+        let config = this.book.config.get('pluginsConfig.katex-plus', {})
+        let macros = config['macros'] || {}
         let output = ''
         try {
           output = katex.renderToString(block.body, {
-            displayMode: false
+            displayMode: false,
+            macros: macros
           })
         } catch (e) {
           console.error(e)


### PR DESCRIPTION
Hi! I am thinking if it is possible to support user-defined macro from katex.
I noticed that one way to do so is to grab the config from book.json and put them into the katex renderer.